### PR TITLE
Allow specifying an attribute that holds the ip to use for monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Attributes
 * `node['nagios']['multi_environment_monitoring']` - Chef server will monitor hosts in all environments, not just its own, default 'false'
 * `node['nagios']['monitored_environments']` - If multi_environment_monitoring is 'true' nagios will monitor nodes in all environments. If monitored_environments is defined then nagios will monitor only hosts in the list of environments defined. For ex: ['prod', 'beta'] will monitor only hosts in 'prod' and 'beta' chef_environments. Defaults to '[]' - and all chef environments will be monitored by default.
 * `node['nagios']['monitoring_interface']` - If set, will use the specified interface for all nagios monitoring network traffic. Defaults to `nil`
+* `node['nagios']['monitoring_attribute']` - If set, will use the specified attribute of the node as the monitored IP. Defaults to `nil`
 
 * `node['nagios']['server']['install_method']` - whether to install from package or source. Default chosen by platform based on known packages available for Nagios: debian/ubuntu 'package', redhat/centos/fedora/scientific: source
 * `node['nagios']['server']['service_name']` - name of the service used for Nagios, default chosen by platform, debian/ubuntu "nagios3", redhat family "nagios", all others, "nagios"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,6 +30,9 @@ default['nagios']['group'] = 'nagios'
 # Allow specifying an interface to use for monitoring traffic
 default['nagios']['monitoring_interface'] = nil
 
+# Allow specifying an attribute that holds the ip to use for monitoring
+default['nagios']['monitoring_attribute'] = nil
+
 case node['platform_family']
 when 'debian'
   default['nagios']['plugin_dir'] = '/usr/lib/nagios/plugins'

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -47,13 +47,13 @@ end
 def ip_to_monitor(monitored_host, server_host = node)
   # if monitoring_address is specified implicitly use that
   attrib_value = nil
-  if !node['nagios']['monitoring_attribute'].nil?
-    attrib_value=monitored_host
+  unless node['nagios']['monitoring_attribute'].nil?
+    attrib_value = monitored_host
     path_ary = node['nagios']['monitoring_attribute'].split('.')
     path_ary.each do |k|
-      if attrib_value and attrib_value.has_key?(k)
+      if attrib_value && attrib_value.key?(k)
         attrib_value = attrib_value[k]
-      elsif attrib_value and attrib_value.respond_to? k
+      elsif attrib_value && attrib_value.respond_to? k
         attrib_value = attrib_value.send(k)
       else
         attrib_value = nil

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -53,7 +53,7 @@ def ip_to_monitor(monitored_host, server_host = node)
     path_ary.each do |k|
       if attrib_value && attrib_value.key?(k)
         attrib_value = attrib_value[k]
-      elsif attrib_value && attrib_value.respond_to? k
+      elsif attrib_value && attrib_value.respond_to?(k)
         attrib_value = attrib_value.send(k)
       else
         attrib_value = nil

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -45,8 +45,25 @@ end
 # if the cloud IP is nil then use the standard IP address attribute.  This is a work around
 #   for OHAI incorrectly identifying systems on Cisco hardware as being in Rackspace
 def ip_to_monitor(monitored_host, server_host = node)
+  # if monitoring_address is specified implicitly use that
+  attrib_value = nil
+  if !node['nagios']['monitoring_attribute'].nil?
+    attrib_value=monitored_host
+    path_ary = node['nagios']['monitoring_attribute'].split('.')
+    path_ary.each do |k|
+      if attrib_value and attrib_value.has_key?(k)
+        attrib_value = attrib_value[k]
+      elsif attrib_value and attrib_value.respond_to? k
+        attrib_value = attrib_value.send(k)
+      else
+        attrib_value = nil
+      end
+    end
+  end
+  if attrib_value
+    attrib_value
   # if interface to monitor is specified implicitly use that
-  if node['nagios']['monitoring_interface'] && node['network']["ipaddress_#{node['nagios']['monitoring_interface']}"]
+  elsif node['nagios']['monitoring_interface'] && node['network']["ipaddress_#{node['nagios']['monitoring_interface']}"]
     node['network']["ipaddress_#{node['nagios']['monitoring_interface']}"]
   # if server is not in the cloud and the monitored host is
   elsif server_host['cloud'].nil? && monitored_host['cloud']


### PR DESCRIPTION
This feature lets you provide an attribute that holds the ip address you want to use as a monitoring address.