### PR TITLE
Support the adding of parents to build the infrastructure map

### DIFF
--- a/templates/default/hosts.cfg.erb
+++ b/templates/default/hosts.cfg.erb
@@ -46,6 +46,7 @@ define host {
   host_name <%= node['nagios']['server']['normalize_hostname'] ? n['id'].downcase : n['id'] %>
   hostgroups all,<%= n['hostgroups'].join(",") %>
   notifications_enabled <%= n['notifications'] %>
+  parents <%= n['parents'] %>
 }
   <% end %>
 <% end -%>


### PR DESCRIPTION
Currently this option is not support so when you look in the map view all the nodes have the nagios process as their parent.