### PR TITLE
setting restriction on the resource.cfg and not on the directory.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -213,10 +213,16 @@ end
 
 # resource.cfg differs on RPM and tarball based systems
 if node['platform_family'] == 'rhel' || node['platform_family'] == 'fedora'
+  file "#{node['nagios']['resource_dir']}/resource.cfg" do
+      owner node['nagios']['user']
+      group node['nagios']['group']
+      mode '0600'
+  end
+
   directory node['nagios']['resource_dir'] do
     owner 'root'
     group node['nagios']['group']
-    mode '0750'
+    mode '0755'
   end
 end
 


### PR DESCRIPTION
Fixes an issues where resource_dir overlaps with the configuration directory. With the 750 permissions apache couldn't access the requires files. As only resource.cfg needs protection we can fix that with file permissions.