### PR TITLE
Bugfixes for running on RHEL 6 under apache2.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,6 +30,9 @@ else
   nagios_service_name = node['nagios']['server']['service_name']
 end
 
+# install nagios service either from source of package
+include_recipe "nagios::server_#{node['nagios']['server']['install_method']}"
+
 # configure either Apache2 or NGINX
 case node['nagios']['server']['web_server']
 when 'nginx'
@@ -47,9 +50,6 @@ else
                   "#{node['nagios']['server']['web_server']} provided. Allowed: 'nginx' or 'apache'")
   fail 'Unknown web server option provided for Nagios server'
 end
-
-# install nagios service either from source of package
-include_recipe "nagios::server_#{node['nagios']['server']['install_method']}"
 
 # use the users_helper.rb library to build arrays of users and contacts
 nagios_users = NagiosUsers.new(node)

--- a/recipes/server_package.rb
+++ b/recipes/server_package.rb
@@ -20,7 +20,7 @@
 #
 
 case node['platform_family']
-when 'fedora'
+when 'fedora', 'rhel'
   include_recipe 'yum-epel' if node['platform_version'].to_i < 17 # setup epel on old rhel and pre Fedora 17
 when 'debian'
   # Nagios package requires to enter the admin password

--- a/templates/default/apache2.conf.erb
+++ b/templates/default/apache2.conf.erb
@@ -11,8 +11,8 @@
 <% end %>
 <% end %>
   DocumentRoot    <%= node['nagios']['docroot'] %>
-  CustomLog       <%= node['nagios']['log_dir'] %>/apache_access.log combined
-  ErrorLog        <%= node['nagios']['log_dir'] %>/apache_error.log
+  CustomLog       <%= node['apache']['log_dir'] %>/nagios_access.log combined
+  ErrorLog        <%= node['apache']['log_dir'] %>/nagios_error.log
 
 <% if node.platform_family == 'debian' && node['nagios']['server']['install_method'] == 'package'-%>
   Alias /<%= node['nagios']['server']['vname'] %>/stylesheets /etc/<%= node['nagios']['server']['vname'] %>/stylesheets


### PR DESCRIPTION
- Install the package first before changing webserver configs; this way, Apache
  won't complain that any paths you need from the nagios package aren't available
- RHEL needs EPEL as well to install Nagios
- The nagios package installs /var/log/nagios as unwriteable by anything other
  than the nagios user, since only its logs go in there. Rather than overriding
  permissions, let's put nagios's Apache access and error logs in apache's own
  directory, named appropriately.